### PR TITLE
Move data dir to comply with the XDG specification

### DIFF
--- a/driver/bolt.go
+++ b/driver/bolt.go
@@ -59,10 +59,10 @@ func CloseBolt() {
 }
 
 func RemoveBolt() error {
-	home, err := os.UserHomeDir()
+	datadir, err := GetDataDir()
 	if err != nil {
-		return fmt.Errorf("$HOME directory not found: %w", err)
+		return err
 	}
 
-	return os.Remove(filepath.Join(home, ".tsk", "bolt.db"))
+	return os.Remove(filepath.Join(datadir, "bolt.db"))
 }

--- a/driver/bolt.go
+++ b/driver/bolt.go
@@ -11,18 +11,33 @@ import (
 
 var db *bbolt.DB
 
+func GetDataDir() (string, error) {
+	dataroot := os.Getenv("XDG_DATA_HOME")
+
+	if dataroot == "" {
+		home, err := os.UserHomeDir()
+		if err != nil {
+			return "", fmt.Errorf("$HOME directory not found: %w", err)
+		}
+		dataroot = filepath.Join(home, ".local", "share")
+	}
+
+	datadir := filepath.Join(dataroot, "tsk")
+	err := os.MkdirAll(datadir, os.ModePerm)
+	if err != nil {
+		return "", fmt.Errorf("failed to create tsk under %s directory: %w", dataroot, err)
+	}
+
+	return datadir, nil
+}
+
 func NewBolt() (*bbolt.DB, error) {
-	home, err := os.UserHomeDir()
+	datadir, err := GetDataDir()
 	if err != nil {
-		return nil, fmt.Errorf("$HOME directory not found: %w", err)
+		return nil, err
 	}
 
-	err = os.MkdirAll(filepath.Join(home, ".tsk"), os.ModePerm)
-	if err != nil {
-		return nil, fmt.Errorf("failed to create .tsk under $HOME directory: %w", err)
-	}
-
-	path := filepath.Join(home, ".tsk", "bolt.db")
+	path := filepath.Join(datadir, "bolt.db")
 
 	_, err = os.OpenFile(path, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0644)
 	if err != nil {


### PR DESCRIPTION
I moved the data dir from `~/.tsk` to comply with the XDG specification (under `$XDG_DATA_HOME`, falling back to `$HOME/.local/share` if not set).

See: https://specifications.freedesktop.org/basedir-spec/basedir-spec-latest.html

(I prefer not to have a lot of dot folders just under my home.)